### PR TITLE
Bug: fix image close button ++

### DIFF
--- a/src/Pages/ChatbotPage/ChatbotPage.module.css
+++ b/src/Pages/ChatbotPage/ChatbotPage.module.css
@@ -39,7 +39,7 @@
   flex: 1;
   padding: 2rem;
   padding-top: 10rem;
-  padding-bottom: 4rem;
+  padding-bottom: 5rem;
   align-items: center;
   gap: 2rem;
   height: 100%;
@@ -116,15 +116,17 @@
 
 @media (max-width: 768px) {
   .headerContainer {
-    padding: 0 1rem;
-    margin-left: 0;
-    align-items: center;
+    display: flex;
+    position: fixed;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 0;
+    gap: 0.5rem;
   }
 
   .chatContainer {
-    padding: 1rem 0.5rem;
+    font-size: medium;
   }
-
   .sendButton {
     height: 2rem;
   }
@@ -143,13 +145,10 @@
   }
 
   .logo {
-    width: 250px;
+    width: 200px;
     margin-left: 20px;
   }
 
-  .chatContainer {
-    font-size: medium;
-  }
 }
 
 @media (max-width: 480px) {

--- a/src/Pages/ChatbotPage/ChatbotPage.module.css
+++ b/src/Pages/ChatbotPage/ChatbotPage.module.css
@@ -108,19 +108,6 @@
   border: 1px solid var(--ds-color-warning-base-contrast-default);
 }
 
-.helperText {
-  font-size: 0.75rem;
-  color: var(--ds-color-neutral-border-default #7c8289);
-  width: 100%;
-  text-align: center;
-  margin-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  word-break: break-word;
-}
-
 @media (max-width: 1314px) {
   .sendContainer {
     width: 90%;
@@ -193,10 +180,6 @@
     font-size: small;
     padding-top: 8rem;
   }
-
-  .helperText {
-    font-size: x-small;
-  }
 }
 
 @media (max-width: 320px) {
@@ -205,9 +188,5 @@
   }
   .chatContainer {
     font-size: x-small;
-  }
-
-  .helperText {
-    font-size: xx-small;
   }
 }

--- a/src/Pages/ChatbotPage/ChatbotPage.module.css
+++ b/src/Pages/ChatbotPage/ChatbotPage.module.css
@@ -148,7 +148,6 @@
     width: 200px;
     margin-left: 20px;
   }
-
 }
 
 @media (max-width: 480px) {

--- a/src/Pages/ChatbotPage/ChatbotPage.tsx
+++ b/src/Pages/ChatbotPage/ChatbotPage.tsx
@@ -173,11 +173,6 @@ export function ChatbotPage({ source }: ChatbotPageProps) {
                 onSend={handleSend}
                 fileInputRef={fileInputRef}
               />
-              <div className={styles.helperText}>
-                Chatboten kan gjøre feil. Kontakt Service Desk på &nbsp;
-                <a href="mailto:servicedesk@digdir.no">servicedesk@digdir.no</a>{' '}
-                &nbsp; hvis du trenger mer hjelp.
-              </div>
             </div>
           </div>
         </div>

--- a/src/Pages/ChatbotPage/ChatbotPage.tsx
+++ b/src/Pages/ChatbotPage/ChatbotPage.tsx
@@ -123,7 +123,7 @@ export function ChatbotPage({ source }: ChatbotPageProps) {
       <div className={styles.mainContainer}>
         <div className={styles.headerContainer}>
           <Link
-            to="/"
+            to={`/${source}`}
             className={styles.logoLink}
             aria-label={t(KEY.go_to_homepage)}
           >

--- a/src/Pages/ChatbotPage/ChatbotPage.tsx
+++ b/src/Pages/ChatbotPage/ChatbotPage.tsx
@@ -161,6 +161,7 @@ export function ChatbotPage({ source }: ChatbotPageProps) {
                 onImageUpload={handleImageUpload}
                 onRemoveImage={handleRemoveImage}
                 fileInputRef={fileInputRef}
+                onImageClick={setFullscreenImage}
               />
 
               <ChatInput

--- a/src/Pages/ChatbotPage/ChatbotPage.tsx
+++ b/src/Pages/ChatbotPage/ChatbotPage.tsx
@@ -5,6 +5,7 @@ import { sendChatMessage } from '~/api/chatApi';
 import { ChatInput } from '~/components/ChatInput/ChatInput';
 import { Chats } from '~/components/Chats/Chats';
 import { DropdownMenu } from '~/components/DropdownMenu/DropdownMenu';
+import { FullscreenImage } from '~/components/FullscreenImage/FullscreenImage';
 import { ImageUpload } from '~/components/ImageUpload/ImageUpload';
 import { Logo } from '~/components/Logo/Logo';
 import { KEY } from '~/i18n/constants';
@@ -35,6 +36,7 @@ export function ChatbotPage({ source }: ChatbotPageProps) {
   const [imageError, setImageError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
+  const [fullscreenImage, setFullscreenImage] = useState<string | null>(null);
 
   const isFirstMessage = messages.length === 0;
 
@@ -108,62 +110,74 @@ export function ChatbotPage({ source }: ChatbotPageProps) {
   }, [messages]);
 
   return (
-    <div className={styles.mainContainer}>
-      <div className={styles.headerContainer}>
-        <Link
-          to="/"
-          className={styles.logoLink}
-          aria-label={t(KEY.go_to_homepage)}
-        >
-          <Logo className={styles.logo} />
-        </Link>
+    <>
+      {fullscreenImage && (
+        <FullscreenImage
+          imageUrl={fullscreenImage}
+          onClose={() => setFullscreenImage(null)}
+        />
+      )}
+      <div className={styles.mainContainer}>
+        <div className={styles.headerContainer}>
+          <Link
+            to="/"
+            className={styles.logoLink}
+            aria-label={t(KEY.go_to_homepage)}
+          >
+            <Logo className={styles.logo} />
+          </Link>
 
-        {/* Stops dropdown menu from rendering if source is brukerstotte */}
-        {source !== 'brukerstotte' && <DropdownMenu />}
-      </div>
-
-      <div
-        className={`${styles.chatContainer} ${
-          isFirstMessage ? styles.chatContainerCentered : ''
-        }`}
-      >
-        <div className={styles.messagesContainer}>
-          <Chats messages={messages} loading={loading} />
-          <div ref={bottomRef} />
+          {/* Stops dropdown menu from rendering if source is brukerstotte */}
+          {source !== 'brukerstotte' && <DropdownMenu />}
         </div>
 
-        {isFirstMessage && (
-          <h2 className={styles.introText}>{t(KEY.chatbot_welcome)}</h2>
-        )}
-
         <div
-          className={`${styles.sendContainer} ${
-            !isFirstMessage ? styles.atBottom : ''
+          className={`${styles.chatContainer} ${
+            isFirstMessage ? styles.chatContainerCentered : ''
           }`}
         >
-          <div className={styles.sendAreaWrapper}>
-            <ImageUpload
-              uploadedImages={uploadedImages}
-              imageError={imageError}
-              onImageUpload={handleImageUpload}
-              onRemoveImage={handleRemoveImage}
-              fileInputRef={fileInputRef}
+          <div className={styles.messagesContainer}>
+            <Chats
+              messages={messages}
+              loading={loading}
+              onImageClick={setFullscreenImage}
             />
+            <div ref={bottomRef} />
+          </div>
 
-            <ChatInput
-              inputValue={inputValue}
-              onInputChange={setInputValue}
-              onSend={handleSend}
-              fileInputRef={fileInputRef}
-            />
-            <div className={styles.helperText}>
-              Chatboten kan gjøre feil. Kontakt Service Desk på &nbsp;
-              <a href="mailto:servicedesk@digdir.no">servicedesk@digdir.no</a>{' '}
-              &nbsp; hvis du trenger mer hjelp.
+          {isFirstMessage && (
+            <h2 className={styles.introText}>{t(KEY.chatbot_welcome)}</h2>
+          )}
+
+          <div
+            className={`${styles.sendContainer} ${
+              !isFirstMessage ? styles.atBottom : ''
+            }`}
+          >
+            <div className={styles.sendAreaWrapper}>
+              <ImageUpload
+                uploadedImages={uploadedImages}
+                imageError={imageError}
+                onImageUpload={handleImageUpload}
+                onRemoveImage={handleRemoveImage}
+                fileInputRef={fileInputRef}
+              />
+
+              <ChatInput
+                inputValue={inputValue}
+                onInputChange={setInputValue}
+                onSend={handleSend}
+                fileInputRef={fileInputRef}
+              />
+              <div className={styles.helperText}>
+                Chatboten kan gjøre feil. Kontakt Service Desk på &nbsp;
+                <a href="mailto:servicedesk@digdir.no">servicedesk@digdir.no</a>{' '}
+                &nbsp; hvis du trenger mer hjelp.
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/ChatBubble/ChatBubble.module.css
+++ b/src/components/ChatBubble/ChatBubble.module.css
@@ -59,37 +59,6 @@
   border: 1px solid #ccc;
 }
 
-.fullscreenOverlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: rgba(0, 0, 0, 0.9);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-}
-
-.fullscreenImage {
-  max-width: 90%;
-  max-height: 90%;
-  border-radius: 8px;
-}
-
-.closeButton {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  font-size: 2rem;
-  background: none;
-  border: none;
-  color: white;
-  cursor: pointer;
-  z-index: 10000;
-}
-
 .bubbleWrapper {
   display: flex;
   flex-direction: column;

--- a/src/components/ChatBubble/ChatBubble.tsx
+++ b/src/components/ChatBubble/ChatBubble.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { KEY } from '~/i18n/constants';
 import styles from './ChatBubble.module.css';
@@ -7,6 +6,7 @@ type Props = {
   message: string;
   sender: 'user' | 'bot';
   imageUrls?: string[];
+  onImageClick?: (url: string) => void;
 };
 
 /**
@@ -16,18 +16,15 @@ type Props = {
  * @param message - The text content of the message.
  * @param sender - Who sent the message ('user' or 'bot').
  * @param imageUrls - Optional list of image URLs to show in the bubble.
+ * @param onImageClick - Optional Callback to handle image click events, allowing images to be displayed in full screen.
  */
-export function ChatBubble({ message, sender, imageUrls }: Props) {
+export function ChatBubble({
+  message,
+  sender,
+  imageUrls,
+  onImageClick,
+}: Props) {
   const { t } = useTranslation();
-  const [fullscreenImage, setFullscreenImage] = useState<string | null>(null);
-
-  function openImageFullscreen(url: string) {
-    setFullscreenImage(url);
-  }
-
-  function closeFullscreen() {
-    setFullscreenImage(null);
-  }
 
   return (
     <>
@@ -44,7 +41,7 @@ export function ChatBubble({ message, sender, imageUrls }: Props) {
                 type="button"
                 onClick={(e) => {
                   e.preventDefault();
-                  openImageFullscreen(url);
+                  onImageClick?.(url);
                 }}
                 className={styles.unstyledButton}
                 aria-label={t(KEY.display_image_fullscreen)}
@@ -68,24 +65,6 @@ export function ChatBubble({ message, sender, imageUrls }: Props) {
           </div>
         )}
       </div>
-
-      {fullscreenImage && (
-        <div className={styles.fullscreenOverlay}>
-          <button
-            className={styles.closeButton}
-            onClick={closeFullscreen}
-            aria-label={t(KEY.close_image)}
-            type="button"
-          >
-            ✕
-          </button>
-          <img
-            src={fullscreenImage}
-            className={styles.fullscreenImage}
-            alt="Fullskjerm bilde"
-          />
-        </div>
-      )}
     </>
   );
 }

--- a/src/components/ChatInput/ChatInput.module.css
+++ b/src/components/ChatInput/ChatInput.module.css
@@ -1,7 +1,8 @@
 .textareaWrapper {
   position: relative;
   width: 100%;
-  margin-bottom: -3rem;
+  height: 100%;
+  padding-bottom: 1rem;
 }
 
 .chatTextarea {
@@ -27,9 +28,11 @@
   justify-content: flex-end;
   background-color: var(--ds-color-neutral-surface-default);
   border-bottom-left-radius: 20px;
-  position: inherit;
+  border-bottom-right-radius: 20px;
+  position: absolute;
   bottom: 3rem;
   margin-right: 1.2rem;
+  width: 100%;
 }
 
 .inputButton {
@@ -49,6 +52,18 @@
   outline: none;
   border: none;
   color: var(--ds-color-neutral-text-subtle);
+}
+
+.helperText {
+  font-size: 0.75rem;
+  color: var(--ds-color-neutral-text-default);
+  width: 100%;
+  text-align: center;
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  word-break: break-word;
 }
 
 @media (min-width: 766px) and (max-width: 1314px) {
@@ -77,6 +92,10 @@
     padding: 10px;
     font-size: 0.9rem;
   }
+
+  .helperText {
+    font-size: x-small;
+  }
 }
 
 @media (max-width: 320px) {
@@ -87,5 +106,9 @@
 
   .input {
     width: 100%;
+  }
+
+  .helperText {
+    font-size: xx-small;
   }
 }

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -73,6 +73,11 @@ export function ChatInput({
           </Button>
         </Tooltip>
       </div>
+      <div className={styles.helperText}>
+        Chatboten kan gjøre feil. Kontakt Service Desk på&nbsp;
+        <a href="mailto:servicedesk@digdir.no">servicedesk@digdir.no</a>&nbsp;
+        hvis du trenger mer hjelp.
+      </div>
     </div>
   );
 }

--- a/src/components/ChatLoader/ChatLoader.module.css
+++ b/src/components/ChatLoader/ChatLoader.module.css
@@ -3,7 +3,8 @@
   flex-direction: row;
   gap: 10px;
   margin-left: 20px;
-  margin-bottom: 4rem;
+  margin-bottom: 3rem;
+  margin-top: 1.5rem;
 }
 
 .messageSkeleton {

--- a/src/components/ChatLoader/ChatLoader.module.css
+++ b/src/components/ChatLoader/ChatLoader.module.css
@@ -3,6 +3,7 @@
   flex-direction: row;
   gap: 10px;
   margin-left: 20px;
+  margin-bottom: 4rem;
 }
 
 .messageSkeleton {

--- a/src/components/Chats/Chats.tsx
+++ b/src/components/Chats/Chats.tsx
@@ -10,6 +10,7 @@ type Message = {
 type ChatsProps = {
   messages: Message[];
   loading?: boolean;
+  onImageClick?: (url: string) => void;
 };
 
 /**
@@ -18,7 +19,7 @@ type ChatsProps = {
  * @param messages - Array of chat messages to display.
  * @param loading - Whether the chatbot is currently loading a response.
  */
-export function Chats({ messages, loading }: ChatsProps) {
+export function Chats({ messages, loading, onImageClick }: ChatsProps) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
       {messages.map((msg, index) => (
@@ -27,6 +28,7 @@ export function Chats({ messages, loading }: ChatsProps) {
           sender={msg.sender}
           message={msg.text}
           imageUrls={msg.imageUrls}
+          onImageClick={onImageClick}
         />
       ))}
 

--- a/src/components/FullscreenImage/FullscreenImage.tsx
+++ b/src/components/FullscreenImage/FullscreenImage.tsx
@@ -1,0 +1,26 @@
+import styles from './FulscreenImage.module.css';
+
+type Props = {
+  imageUrl: string;
+  onClose: () => void;
+};
+
+export function FullscreenImage({ imageUrl, onClose }: Props) {
+  return (
+    <div className={styles.fullscreenOverlay}>
+      <button
+        onClick={onClose}
+        className={styles.closeButton}
+        type="button"
+        aria-label="Lukk bilde"
+      >
+        ✕
+      </button>
+      <img
+        src={imageUrl}
+        alt="Fullskjerm bilde"
+        className={styles.fullscreenImage}
+      />
+    </div>
+  );
+}

--- a/src/components/FullscreenImage/FulscreenImage.module.css
+++ b/src/components/FullscreenImage/FulscreenImage.module.css
@@ -1,0 +1,30 @@
+.fullscreenOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.fullscreenImage {
+  max-width: 90%;
+  max-height: 90%;
+  border-radius: 8px;
+}
+
+.closeButton {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 2rem;
+  background: none;
+  border: none;
+  color: white;
+  cursor: pointer;
+  z-index: 10000;
+}

--- a/src/components/ImageUpload/ImageUpload.module.css
+++ b/src/components/ImageUpload/ImageUpload.module.css
@@ -13,6 +13,15 @@
   object-fit: cover;
   border-radius: 6px;
   border: 1px solid var(--ds-color-warning-base-contrast-default);
+
+  /* Checkerboard background for transparency */
+  background-color: #fff;
+  background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-size: 10px 10px;
+  background-position: 0 0, 0 5px, 5px -5px, -5px 0px;
 }
 
 .removeImageButton {

--- a/src/components/ImageUpload/ImageUpload.module.css
+++ b/src/components/ImageUpload/ImageUpload.module.css
@@ -5,38 +5,43 @@
 .imageWrapper {
   position: relative;
   display: inline-block;
+  width: 80px;
+  height: 80px;
+  margin-right: 50px;
 }
 
 .imagePreview {
-  width: 80px;
-  height: 80px;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
-  border-radius: 6px;
-  border: 1px solid var(--ds-color-warning-base-contrast-default);
+  border-radius: 10px;
+  border: 17px solid var(--ds-color-neutral-surface-default);
 
   /* Checkerboard background for transparency */
-  background-color: #fff;
+  /* background-color: #fff;
   background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
     linear-gradient(-45deg, #ccc 25%, transparent 25%),
     linear-gradient(45deg, transparent 75%, #ccc 75%),
     linear-gradient(-45deg, transparent 75%, #ccc 75%);
-  background-size: 10px 10px;
-  background-position: 0 0, 0 5px, 5px -5px, -5px 0px;
+  background-size: 15px 15px;
+  background-position: 0 0, 0 7.5px, 7.5px -7.5px, -7.5px 0px; */
+
+  background-color: var(--ds-color-neutral-surface-default);
+  /* padding: 20px; */
 }
 
 .removeImageButton {
   position: absolute;
-  top: -6px;
-  right: -6px;
+  top: 1px;
+  right: -39px;
   background: transparent;
   border: none;
   border-radius: 50%;
   cursor: pointer;
-  width: 20px;
-  height: 20px;
-  font-size: 12px;
+  font-size: large;
   line-height: 20px;
   text-align: center;
+  color: var(--ds-color-main-text-default);
 }
 
 .imageError {

--- a/src/components/ImageUpload/ImageUpload.module.css
+++ b/src/components/ImageUpload/ImageUpload.module.css
@@ -5,14 +5,12 @@
 .imageWrapper {
   position: relative;
   display: inline-block;
-  width: 80px;
-  height: 80px;
-  margin-right: 50px;
+  margin-right: 15px;
 }
 
 .imagePreview {
-  width: 100%;
-  height: 100%;
+  width: 80px;
+  height: 80px;
   object-fit: cover;
   border-radius: 10px;
   border: 17px solid var(--ds-color-neutral-surface-default);
@@ -27,13 +25,13 @@
   background-position: 0 0, 0 7.5px, 7.5px -7.5px, -7.5px 0px; */
 
   background-color: var(--ds-color-neutral-surface-default);
-  /* padding: 20px; */
+  padding: 5px;
 }
 
 .removeImageButton {
   position: absolute;
   top: 1px;
-  right: -39px;
+  right: -3px;
   background: transparent;
   border: none;
   border-radius: 50%;
@@ -42,6 +40,15 @@
   line-height: 20px;
   text-align: center;
   color: var(--ds-color-main-text-default);
+}
+
+.imageButton {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  display: inline;
 }
 
 .imageError {

--- a/src/components/ImageUpload/ImageUpload.module.css
+++ b/src/components/ImageUpload/ImageUpload.module.css
@@ -14,16 +14,6 @@
   object-fit: cover;
   border-radius: 10px;
   border: 17px solid var(--ds-color-neutral-surface-default);
-
-  /* Checkerboard background for transparency */
-  /* background-color: #fff;
-  background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
-    linear-gradient(-45deg, #ccc 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, #ccc 75%),
-    linear-gradient(-45deg, transparent 75%, #ccc 75%);
-  background-size: 15px 15px;
-  background-position: 0 0, 0 7.5px, 7.5px -7.5px, -7.5px 0px; */
-
   background-color: var(--ds-color-neutral-surface-default);
   padding: 5px;
 }

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -1,3 +1,4 @@
+import { XMarkIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { KEY } from '~/i18n/constants';
 import styles from './ImageUpload.module.css';
@@ -30,14 +31,14 @@ export function ImageUpload({
                 alt={`Bilde ${index + 1}`}
                 className={styles.imagePreview}
               />
-              <button
-                className={styles.removeImageButton}
-                onClick={() => onRemoveImage(index)}
-                aria-label={`${t(KEY.remove_image)} ${index + 1}`}
-                type="button"
-              >
-                ✖
-              </button>
+                <button
+                  className={styles.removeImageButton}
+                  onClick={() => onRemoveImage(index)}
+                  aria-label={`${t(KEY.remove_image)} ${index + 1}`}
+                  type="button"
+                >
+                  <XMarkIcon />
+                </button>
             </div>
           ))}
         </div>

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -37,7 +37,6 @@ export function ImageUpload({
                   src={url}
                   alt={`Bilde ${index + 1}`}
                   className={styles.imagePreview}
-                  onClick={() => onImageClick?.(url)}
                 />
               </button>
               <button

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -9,6 +9,7 @@ type Props = {
   onImageUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onRemoveImage: (index: number) => void;
   fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onImageClick?: (url: string) => void;
 };
 
 export function ImageUpload({
@@ -17,6 +18,7 @@ export function ImageUpload({
   onImageUpload,
   onRemoveImage,
   fileInputRef,
+  onImageClick,
 }: Props) {
   const { t } = useTranslation();
 
@@ -26,11 +28,18 @@ export function ImageUpload({
         <div className={styles.previewContainer}>
           {uploadedImages.map((url, index) => (
             <div key={index} className={styles.imageWrapper}>
-              <img
-                src={url}
-                alt={`Bilde ${index + 1}`}
-                className={styles.imagePreview}
-              />
+              <button
+                className={styles.imageButton}
+                type="button"
+                onClick={() => onImageClick?.(url)}
+              >
+                <img
+                  src={url}
+                  alt={`Bilde ${index + 1}`}
+                  className={styles.imagePreview}
+                  onClick={() => onImageClick?.(url)}
+                />
+              </button>
               <button
                 className={styles.removeImageButton}
                 onClick={() => onRemoveImage(index)}

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -31,14 +31,14 @@ export function ImageUpload({
                 alt={`Bilde ${index + 1}`}
                 className={styles.imagePreview}
               />
-                <button
-                  className={styles.removeImageButton}
-                  onClick={() => onRemoveImage(index)}
-                  aria-label={`${t(KEY.remove_image)} ${index + 1}`}
-                  type="button"
-                >
-                  <XMarkIcon />
-                </button>
+              <button
+                className={styles.removeImageButton}
+                onClick={() => onRemoveImage(index)}
+                aria-label={`${t(KEY.remove_image)} ${index + 1}`}
+                type="button"
+              >
+                <XMarkIcon />
+              </button>
             </div>
           ))}
         </div>


### PR DESCRIPTION
### Changes done in this pr:
- Made the fullscreen image overlay its own component and it is now rendering outside the main container, so that it can be placed in front over the headercontainer. This also solved the problem of the cross out button not being visible
- Changed the styling of the preview images in the input field
  - <img width="1132" height="275" alt="image" src="https://github.com/user-attachments/assets/45c8217c-8b60-4b5b-af0f-f8acea8283d6" />

- Added fullscreen functionality to preview images as well.
- Made the email link in the helper text work again by moving helpertext to ChatInput.tsx and make the buttons class smaller, so that it is not in front of the helper text. 
- Fixed the logo link to match brukerstotte vs servicedesk
- Added margin-bottom to the chatloader in order for it to still be visible after the page has scrolled.

### Something I tried
<img width="1134" height="269" alt="image" src="https://github.com/user-attachments/assets/2a244adf-27d2-4f6a-8855-5a4cfd1579bc" />
I tried adding a checkerboard background to highlight transparent images, but felt that it was a bit ugly. I am however open to adding it back 😅. Could also potentially add it to the fullscreen overlay

### To do next in order:
- Translate all text that is not translated yet 
- Switch to brukerstotte mail when on brukerstotte
- Make the image error message a popup
- Fix the color of the text in the dropdown menues
- Make the logo in the ChatbotPage a bit smaller